### PR TITLE
Fix/ conflicting declaration of C function ‘char* strdup(char*)’

### DIFF
--- a/src/util/libekr/r_common.h
+++ b/src/util/libekr/r_common.h
@@ -92,9 +92,9 @@
 #include "r_data.h"
 
 /* defines for possibly replaced functions */
-#ifndef HAVE_STRDUP
-char *strdup(char *in);
-#endif
+//#ifndef HAVE_STRDUP
+//char *strdup(char *in);
+//#endif
 
 #endif
 


### PR DESCRIPTION
error: conflicting declaration of C function ‘char* strdup(char*)’